### PR TITLE
Bunch of housekeeping to make the sample app easier to use

### DIFF
--- a/pelias-ios-sdk/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/pelias-ios-sdk/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -59,6 +59,11 @@
       "idiom" : "ipad",
       "size" : "76x76",
       "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "83.5x83.5",
+      "scale" : "2x"
     }
   ],
   "info" : {

--- a/pelias-ios-sdk/AutocompleteTableVC.swift
+++ b/pelias-ios-sdk/AutocompleteTableVC.swift
@@ -94,6 +94,11 @@ class AutocompleteTableVC: UITableViewController, UISearchResultsUpdating, UISea
     print(error)
   }
   
+  override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
+    searchController.searchBar.resignFirstResponder()
+    tableView.deselectRowAtIndexPath(indexPath, animated: true)
+  }
+  
   
   /*
   // Override to support conditional editing of the table view.

--- a/pelias-ios-sdk/Base.lproj/Main.storyboard
+++ b/pelias-ios-sdk/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="49e-Tb-3d3">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9531" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="49e-Tb-3d3">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
@@ -24,7 +24,7 @@
                                     <action selector="searchTapped:" destination="9pv-A4-QxB" eventType="touchUpInside" id="dls-VW-BJq"/>
                                 </connections>
                             </button>
-                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" text="Your Search Result Will Get Replaced Here" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="L0e-v3-oP9">
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" text="Your Search Result Will Get Replaced Here" textAlignment="natural" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="L0e-v3-oP9">
                                 <rect key="frame" x="20" y="88" width="560" height="455"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
@@ -36,7 +36,7 @@
                                     <constraint firstAttribute="width" constant="329" id="3CI-Hk-UVc"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits"/>
+                                <textInputTraits key="textInputTraits" returnKeyType="search"/>
                                 <variation key="default">
                                     <mask key="constraints">
                                         <exclude reference="3CI-Hk-UVc"/>
@@ -71,7 +71,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="W5J-7L-Pyd" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="750" y="-320"/>
+            <point key="canvasLocation" x="711" y="-322"/>
         </scene>
         <!--Map Test-->
         <scene sceneID="wg7-f3-ORb">
@@ -133,14 +133,47 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="4Nw-L8-lE0" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="750" y="360"/>
+            <point key="canvasLocation" x="711" y="360"/>
+        </scene>
+        <!--Autocomplete-->
+        <scene sceneID="ZJd-aZ-j54">
+            <objects>
+                <viewController id="Zlg-4L-Wor" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="vlW-DG-OSZ"/>
+                        <viewControllerLayoutGuide type="bottom" id="ihE-0F-rsi"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="eYD-He-YLx">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="l3A-He-b7i">
+                                <rect key="frame" x="0.0" y="20" width="600" height="531"/>
+                                <connections>
+                                    <segue destination="WxQ-1e-D6m" kind="embed" id="FOs-6V-Z0e"/>
+                                </connections>
+                            </containerView>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstAttribute="trailingMargin" secondItem="l3A-He-b7i" secondAttribute="trailing" constant="-20" id="8Yo-TD-GTo"/>
+                            <constraint firstItem="l3A-He-b7i" firstAttribute="top" secondItem="vlW-DG-OSZ" secondAttribute="bottom" id="O9q-HE-TsT"/>
+                            <constraint firstItem="l3A-He-b7i" firstAttribute="leading" secondItem="eYD-He-YLx" secondAttribute="leadingMargin" constant="-20" id="OsK-QB-xfc"/>
+                            <constraint firstItem="ihE-0F-rsi" firstAttribute="top" secondItem="l3A-He-b7i" secondAttribute="bottom" id="ZFr-4o-qaP"/>
+                        </constraints>
+                    </view>
+                    <tabBarItem key="tabBarItem" title="Autocomplete" id="84c-Sa-oaT"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="yo1-Yf-tFc" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="0.0" y="1054"/>
         </scene>
         <!--Autocomplete-->
         <scene sceneID="uYh-0X-Meh">
             <objects>
                 <tableViewController id="WxQ-1e-D6m" customClass="AutocompleteTableVC" customModule="pelias_ios_sdk" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="lso-BI-hiZ">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="531"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <prototypes>
@@ -148,11 +181,11 @@
                                 <rect key="frame" x="0.0" y="28" width="600" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="LQx-X1-NXX" id="fVG-tv-wXb">
-                                    <rect key="frame" x="0.0" y="0.0" width="600" height="43"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="600" height="43.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="QXj-Xu-Sbz">
-                                            <rect key="frame" x="15" y="0.0" width="570" height="43"/>
+                                            <rect key="frame" x="15" y="0.0" width="570" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -184,9 +217,9 @@
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                     </tabBar>
                     <connections>
-                        <segue destination="9pv-A4-QxB" kind="relationship" relationship="viewControllers" id="u7Y-xg-7CH"/>
-                        <segue destination="8rJ-Kc-sve" kind="relationship" relationship="viewControllers" id="lzU-1b-eKA"/>
-                        <segue destination="WxQ-1e-D6m" kind="relationship" relationship="viewControllers" id="xnL-Xv-sy8"/>
+                        <segue destination="8rJ-Kc-sve" kind="relationship" relationship="viewControllers" id="1QP-Wj-9Gg"/>
+                        <segue destination="Zlg-4L-Wor" kind="relationship" relationship="viewControllers" id="y6K-eT-qfY"/>
+                        <segue destination="9pv-A4-QxB" kind="relationship" relationship="viewControllers" id="OiF-eB-8jl"/>
                     </connections>
                 </tabBarController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="HuB-VB-40B" sceneMemberID="firstResponder"/>

--- a/pelias-ios-sdk/FirstViewController.swift
+++ b/pelias-ios-sdk/FirstViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class FirstViewController: UIViewController {
+class FirstViewController: UIViewController, UITextFieldDelegate {
 
   @IBOutlet weak var searchField: UITextField!
   @IBOutlet weak var responseTextView: UITextView!
@@ -16,15 +16,21 @@ class FirstViewController: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
     // Do any additional setup after loading the view, typically from a nib.
+    searchField.delegate = self
   }
 
   override func didReceiveMemoryWarning() {
     super.didReceiveMemoryWarning()
     // Dispose of any resources that can be recreated.
   }
+  
+  func textFieldShouldReturn(textField: UITextField) -> Bool {
+    searchTapped(textField)
+    return true
+  }
 
   @IBAction func searchTapped(sender: AnyObject) {
-    
+    searchField.resignFirstResponder()
     if let searchText = searchField.text{
       let searchConfig = PeliasSearchConfig(searchText: searchText, completionHandler: { (searchResponse) -> Void in
         self.responseTextView.text = NSString.init(format: "%@", searchResponse.parsedResponse!) as String


### PR DESCRIPTION
- Enables return key on the results log keyboard to do a search
- Embeds the autocomplete table insider a container view to prevent it from going under the status bar
- Enables when you tap on a result in autocomplete it dismisses the keyboard
- Changes tab layout so map is first.
