### PR TITLE
Create NSError if not valid geojson

### DIFF
--- a/pelias-ios-sdkTests/PeliasSearchManagerTests.swift
+++ b/pelias-ios-sdkTests/PeliasSearchManagerTests.swift
@@ -56,15 +56,17 @@ class PeliasSearchManagerTests: XCTestCase {
 //  }
 
   func testResponseObjectEncoding() {
-    let seed: NSDictionary = ["SuperSweetKey": "SuperSweetValue"]
+    let seed: Dictionary = ["SuperSweetKey": "SuperSweetValue"]
     
     let testResponse = PeliasSearchResponse(parsedResponse: seed)
     
     PeliasSearchResponse.encode(testResponse)
     
     let decodedObject = PeliasSearchResponse.decode()
-    XCTAssert(testResponse.parsedResponse == decodedObject?.parsedResponse)
+    guard let response = decodedObject?.parsedResponse else { return }
+    XCTAssertTrue(testResponse.parsedResponse.elementsEqual(response, by: { (obj1, obj2) -> Bool in
+      return obj1.key == obj2.key && obj1.value as? String == obj2.value as? String
+    }))
   }
-  
-  
+
 }

--- a/src/PeliasSearchManager.swift
+++ b/src/PeliasSearchManager.swift
@@ -184,13 +184,9 @@ open class PeliasResponse: APIResponse {
   }
 
   fileprivate func parseData<T>(_ data: Data?) -> T?  {
-    guard let JSONData = data else { return nil }
-    do {
-      return try JSONSerialization.jsonObject(with: JSONData, options:JSONSerialization.ReadingOptions(rawValue: 0)) as? T
-    }
-    catch {
-    }
-    return nil
+    guard let jsonData = data else { return nil }
+    let jsonObj = try? JSONSerialization.jsonObject(with: jsonData, options: .mutableContainers)
+    return jsonObj as? T
   }
 }
 

--- a/src/PeliasSearchManager.swift
+++ b/src/PeliasSearchManager.swift
@@ -167,36 +167,28 @@ open class PeliasResponse: APIResponse {
     self.data = data
     self.response = response
     self.error = error
-    if let dictResponse = parseData(data) {
-      if let type = dictResponse.value(forKey: "type") as? String {
+    if let dictResponse: Dictionary<String, Any> = parseData(data) {
+      if let type = dictResponse["type"] as? String {
         if PeliasResponse.validTypes.contains(type) {
           parsedResponse = PeliasSearchResponse(parsedResponse: dictResponse)
         }
       } else {
-        let meta = dictResponse.object(forKey: "meta") as? NSDictionary
-        guard let code = meta?.object(forKey: "status_code") as? Int else { return }
-        let results = dictResponse.object(forKey: "results") as? NSDictionary
-        let error = results?.object(forKey: "error")  as? NSDictionary
-        guard let message = error?.object(forKey: "message") else { return }
+        let meta = dictResponse["meta"] as? NSDictionary
+        guard let code = meta?["status_code"] as? Int else { return }
+        let results = dictResponse["results"] as? NSDictionary
+        let error = results?["error"]  as? NSDictionary
+        guard let message = error?["message"] else { return }
         self.error = NSError.init(domain: "Pelias", code: code, userInfo: [NSLocalizedDescriptionKey:message])
       }
     }
   }
 
-  fileprivate func parseData(_ data: Data?) -> NSDictionary? {
+  fileprivate func parseData<T>(_ data: Data?) -> T?  {
     guard let JSONData = data else { return nil }
     do {
-      let JSON = try JSONSerialization.jsonObject(with: JSONData, options:JSONSerialization.ReadingOptions(rawValue: 0))
-      guard let JSONDictionary :NSDictionary = JSON as? NSDictionary else {
-        print("Not a Dictionary")
-        // put in function
-        return nil
-      }
-      print("JSONDictionary! \(JSONDictionary)")
-      return JSONDictionary
+      return try JSONSerialization.jsonObject(with: JSONData, options:JSONSerialization.ReadingOptions(rawValue: 0)) as? T
     }
-    catch let JSONError as NSError {
-      print("\(JSONError)")
+    catch {
     }
     return nil
   }
@@ -205,10 +197,10 @@ open class PeliasResponse: APIResponse {
 /// Response that can be saved to disk
 public struct PeliasSearchResponse {
   /// Response data that will be saved to disk.
-  public let parsedResponse: NSDictionary
+  public let parsedResponse: Dictionary<String, Any>
 
   /// Constructs a new response given a response dictionary from the server.
-  public init(parsedResponse: NSDictionary) {
+  public init(parsedResponse: Dictionary<String, Any>) {
     self.parsedResponse = parsedResponse
   }
 
@@ -249,7 +241,7 @@ extension PeliasSearchResponse {
     }
     
     public required init?(coder aDecoder: NSCoder) {
-      guard let parsedResponse = aDecoder.decodeObject(forKey: "parsedResponse") as? NSDictionary else { response = nil; super.init(); return nil }
+      guard let parsedResponse = aDecoder.decodeObject(forKey: "parsedResponse") as? Dictionary<String, Any> else { response = nil; super.init(); return nil }
       
       response = PeliasSearchResponse(parsedResponse: parsedResponse)
       


### PR DESCRIPTION
This PR updates the code to treat anything that isnt valid geojson like an http error. So this response:
```
meta =     {
        "status_code" = 429;
        version = 1;
    };
    results =     {
        error =         {
            message = "Queries per second exceeded: Queries exceeded (6 allowed).";
            type = QpsExceededError;
        };
    };
```
will be treated as if the http code `429 Too Many Requests` was received. An `NSError` will be created with code `429` and description `Queries per second exceeded: Queries exceeded (6 allowed).`

It also only creates a parsed response if there is valid geojson