### PR TITLE
Fix query params not appending when autocomplete delay set

### DIFF
--- a/pelias-ios-sdkTests/PeliasSearchManagerTests.swift
+++ b/pelias-ios-sdkTests/PeliasSearchManagerTests.swift
@@ -69,4 +69,21 @@ class PeliasSearchManagerTests: XCTestCase {
     }))
   }
 
+  func testQueryParamsAppended() {
+    PeliasSearchManager.sharedInstance.autocompleteTimeDelay = 10.0
+    PeliasSearchManager.sharedInstance.urlQueryItems = [URLQueryItem.init(name: "query_item", value: "query_item_value")]
+    let point = GeoPoint.init(latitude: 40.0, longitude: 70.0)
+    let config = PeliasAutocompleteConfig.init(searchText: "test", focusPoint: point) { (response) in
+      //
+    }
+    _ = PeliasSearchManager.sharedInstance.autocompleteQuery(config)
+    _ = PeliasSearchManager.sharedInstance.autocompleteQuery(config)
+
+    let searchUrlStr = PeliasSearchManager.sharedInstance.queuedAutocompleteOp?.config.searchUrl().absoluteString
+    XCTAssertTrue((searchUrlStr?.contains("query_item=query_item_value"))!)
+    XCTAssertTrue((searchUrlStr?.contains("text=test"))!)
+    XCTAssertTrue((searchUrlStr?.contains("focus.point.lat=40.0"))!)
+    XCTAssertTrue((searchUrlStr?.contains("focus.point.lon=70.0"))!)
+  }
+
 }

--- a/src/PeliasSearchManager.swift
+++ b/src/PeliasSearchManager.swift
@@ -64,8 +64,8 @@ public final class PeliasSearchManager {
     self.operationQueue.cancelAllOperations()
     self.autocompleteOperationQueue.cancelAllOperations()
   }
-  
-  fileprivate func executeOperation(_ config: APIConfigData) -> PeliasOperation {
+
+  fileprivate func createOperation(_ config: APIConfigData) -> PeliasOperation {
     //Convert to mutable version, and append any query items we have waiting for us
     var configData = config
     if let urlQueryItems = urlQueryItems {
@@ -74,8 +74,11 @@ public final class PeliasSearchManager {
       }
     }
     //Build a operation
-    let searchOp = PeliasOperation(config: configData)
-    
+    return PeliasOperation(config: configData)
+  }
+  
+  fileprivate func executeOperation(_ config: APIConfigData) -> PeliasOperation {
+    let searchOp = createOperation(config)
     //Enqueue search object so it can begin processing
     operationQueue.addOperation(searchOp)
     
@@ -89,7 +92,7 @@ public final class PeliasSearchManager {
       return executeOperation(config)
     }
     
-    let operation = PeliasOperation(config: config)
+    let operation = createOperation(config)
     queuedAutocompleteOp = operation
     // We may be executing an existing operation, so lets see if we have a timer
     // Conceivably this could get called from multiple threads, in which case we should probably synchronize on the timer variable. We'll deal with that if it comes to that


### PR DESCRIPTION
Common `SearchManager` query params were not being appended to requests when the client side rate limiter was used. Adds testing too.