### PR TITLE
Update Pelias to allow URL Session Configuration to be set / modified

### DIFF
--- a/Pelias.podspec
+++ b/Pelias.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             =  'Pelias'
-  s.version          =  '1.0.1'
+  s.version          =  '1.0.2'
   s.summary          =  'A distributed full-text geographic search engine. An open source project sponsored by Mapzen.'
   s.homepage         =  'https://github.com/pelias/pelias-ios-sdk'
   s.social_media_url =  'https://twitter.com/mapzen'

--- a/PeliasTests/PeliasSearchManagerTests.swift
+++ b/PeliasTests/PeliasSearchManagerTests.swift
@@ -86,4 +86,18 @@ class PeliasSearchManagerTests: XCTestCase {
     XCTAssertTrue((searchUrlStr?.contains("focus.point.lon=70.0"))!)
   }
 
+  func testSessionConfiguration() {
+    let point = GeoPoint.init(latitude: 40.0, longitude: 70.0)
+    let config = PeliasAutocompleteConfig.init(searchText: "test", focusPoint: point) { (response) in
+      //
+    }
+    let operation = PeliasOperation(config: config)
+
+    let sessionConfig = URLSessionConfiguration.ephemeral
+    operation.sessionConfig = sessionConfig
+    XCTAssertEqual(operation.session.configuration, URLSession.shared.configuration)
+    operation.main()
+    XCTAssertEqual(operation.session.configuration, sessionConfig)
+  }
+
 }

--- a/Sources/Core/PeliasSearchManager.swift
+++ b/Sources/Core/PeliasSearchManager.swift
@@ -124,6 +124,10 @@ public final class PeliasSearchManager {
 open class PeliasOperation: Operation {
   
   let config: APIConfigData
+  var session = URLSession.shared
+
+  /// An optional configuration you can pass to the underlying URLSession system if you need some special handling.
+  public var sessionConfig: URLSessionConfiguration?
 
   /**
    Creates a new operation given a config. The config will be used to construct a proper response object.
@@ -138,7 +142,11 @@ open class PeliasOperation: Operation {
       return
     }
 
-    URLSession.shared.dataTask(with: config.searchUrl()) { (data, response, error) in
+    if let sessionConfig = sessionConfig {
+      session = URLSession(configuration: sessionConfig)
+    }
+    
+    session.dataTask(with: config.searchUrl()) { (data, response, error) in
       if self.isCancelled {
         return
       }


### PR DESCRIPTION
### Overview
As part of the work to enable us to modify the user agent tracking in the Mapzen iOS SDK, we need a way to tap into the URL Session headers available in the session configuration. This PR enables that.

### Proposed Changes
- Expose a session configuration to enable headers to be modified.
- Expose the URLSession object internally to allow testing. 