### PR TITLE
Add additional http header parsing to the manager

### DIFF
--- a/PeliasTests/PeliasSearchManagerTests.swift
+++ b/PeliasTests/PeliasSearchManagerTests.swift
@@ -16,6 +16,7 @@ class PeliasSearchManagerTests: XCTestCase {
     super.setUp()
     // Put setup code here. This method is called before the invocation of each test method in the class.
     testOperationQueue.isSuspended = true
+    PeliasSearchManager.sharedInstance.operationQueue.isSuspended = true
     PeliasSearchManager.sharedInstance.autocompleteTimeDelay = 0.0
   }
   
@@ -98,6 +99,23 @@ class PeliasSearchManagerTests: XCTestCase {
     XCTAssertEqual(operation.session.configuration, URLSession.shared.configuration)
     operation.main()
     XCTAssertEqual(operation.session.configuration, sessionConfig)
+  }
+
+  func testAddingHttpHeaders() {
+    let testHeaders = ["Hello" : "Hi"]
+    PeliasSearchManager.sharedInstance.additionalHttpHeaders = testHeaders
+
+    let point = GeoPoint.init(latitude: 40.0, longitude: 70.0)
+    let config = PeliasAutocompleteConfig.init(searchText: "test", focusPoint: point) { (response) in
+      //
+    }
+    let testOp = PeliasSearchManager.sharedInstance.autocompleteQuery(config)
+    XCTAssertNotNil(testOp.sessionConfig, "Session configuration not created for additional headers")
+    guard let sessionheaders = testOp.sessionConfig?.httpAdditionalHeaders else {
+      XCTFail("Headers dictionary not created")
+      return
+    }
+    XCTAssertEqual(sessionheaders["Hello"] as? String, testHeaders["Hello"])
   }
 
 }

--- a/Sources/Core/PeliasSearchManager.swift
+++ b/Sources/Core/PeliasSearchManager.swift
@@ -23,6 +23,7 @@ public final class PeliasSearchManager {
   public var baseUrl: URL
   /// The query items that should be applied to every request (such as an api key).
   public var urlQueryItems: [URLQueryItem]?
+  // Additional HTTP Headers to append to outbound requests
   public var additionalHttpHeaders: [String:String]?
   
   fileprivate init() {

--- a/Sources/Core/PeliasSearchManager.swift
+++ b/Sources/Core/PeliasSearchManager.swift
@@ -13,7 +13,7 @@ public final class PeliasSearchManager {
   
   //! Singleton access
   public static let sharedInstance = PeliasSearchManager()
-  fileprivate let operationQueue = OperationQueue()
+  internal let operationQueue = OperationQueue()
   fileprivate let autocompleteOperationQueue = OperationQueue()
   fileprivate var autocompleteQueryTimer: Timer?
   internal var queuedAutocompleteOp: PeliasOperation?
@@ -23,6 +23,7 @@ public final class PeliasSearchManager {
   public var baseUrl: URL
   /// The query items that should be applied to every request (such as an api key).
   public var urlQueryItems: [URLQueryItem]?
+  public var additionalHttpHeaders: [String:String]?
   
   fileprivate init() {
     operationQueue.maxConcurrentOperationCount = 4
@@ -73,8 +74,16 @@ public final class PeliasSearchManager {
         configData.appendQueryItem(queryItem.name, value: queryItem.value)
       }
     }
+
+    let operation = PeliasOperation(config: configData)
+    if let headers = additionalHttpHeaders {
+      let config = URLSessionConfiguration.default
+      config.httpAdditionalHeaders = headers
+      operation.sessionConfig = config
+    }
+
     //Build a operation
-    return PeliasOperation(config: configData)
+    return operation
   }
   
   fileprivate func executeOperation(_ config: APIConfigData) -> PeliasOperation {


### PR DESCRIPTION
### Overview
Enable additional HTTP header parsing for pelias's SDK.
### Proposed Changes
- Add public variable for http header additions
- Expose operation queue to make testing a little easier (avoids network processing in tests)